### PR TITLE
[codex] Store Moltnet install state under home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Moltnet are recorded here.
 
 ## Unreleased
 
+- Changed release install/update ownership metadata to use `~/.moltnet/install.json` by default, with `MOLTNET_HOME` as the override.
+
 ## v0.1.0 — 2026-04-24
 
 - Hardened HTTP error handling so 5xx responses no longer expose raw internal error strings.

--- a/internal/updater/install.go
+++ b/internal/updater/install.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
+
+const moltnetHomeEnv = "MOLTNET_HOME"
 
 type DefaultInstallDetector struct{}
 
@@ -94,7 +95,7 @@ func writeInstallMetadata(metadata installMetadata) error {
 	contents = append(contents, '\n')
 
 	directory := filepath.Dir(path)
-	if err := os.MkdirAll(directory, 0o700); err != nil {
+	if err := ensurePrivateDirectory(directory, "install metadata directory"); err != nil {
 		return err
 	}
 	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
@@ -153,6 +154,12 @@ func isContainerInstall() bool {
 func loadInstallMetadata() (installMetadata, bool) {
 	path := defaultInstallMetadataPath()
 	if path == "" {
+		return installMetadata{}, false
+	}
+	if err := validatePrivateDirectory(filepath.Dir(path), "install metadata directory"); err != nil {
+		return installMetadata{}, false
+	}
+	if err := validatePrivateRegularFile(path, "install metadata"); err != nil {
 		return installMetadata{}, false
 	}
 	contents, err := os.ReadFile(path)
@@ -230,18 +237,71 @@ func normalizeAssetChecksum(checksum string) string {
 	return "sha256:" + trimmed
 }
 
+func validatePrivateDirectory(path string, label string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s %q must not be a symlink", label, path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s %q must be a directory", label, path)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("%s %q must not be group/world accessible", label, path)
+	}
+	return nil
+}
+
+func ensurePrivateDirectory(path string, label string) error {
+	if _, err := os.Lstat(path); os.IsNotExist(err) {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	return validatePrivateDirectory(path, label)
+}
+
+func validatePrivateRegularFile(path string, label string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s %q must not be a symlink", label, path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s %q must be a regular file", label, path)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("%s %q must not be group/world accessible", label, path)
+	}
+	return nil
+}
+
 func defaultInstallMetadataPath() string {
-	if stateHome := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); stateHome != "" {
-		return filepath.Join(stateHome, "moltnet", "install.json")
+	home := defaultMoltnetHome()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, "install.json")
+}
+
+func defaultMoltnetHome() string {
+	if override := strings.TrimSpace(os.Getenv(moltnetHomeEnv)); override != "" {
+		if absolute, err := filepath.Abs(override); err == nil {
+			return absolute
+		}
+		return filepath.Clean(override)
 	}
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return ""
 	}
-	if runtime.GOOS == "darwin" {
-		return filepath.Join(home, "Library", "Application Support", "moltnet", "install.json")
-	}
-	return filepath.Join(home, ".local", "state", "moltnet", "install.json")
+	return filepath.Join(home, ".moltnet")
 }
 
 func samePath(left string, right string) bool {

--- a/internal/updater/install_script_test.go
+++ b/internal/updater/install_script_test.go
@@ -1,0 +1,333 @@
+package updater
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestInstallScriptWritesMoltnetHomeMetadata(t *testing.T) {
+	assetName, err := AssetName(Platform{OS: runtime.GOOS, Arch: runtime.GOARCH})
+	if err != nil {
+		t.Skipf("unsupported test platform: %v", err)
+	}
+	archive := archiveWithEntries(t, archiveEntry{
+		name: "moltnet",
+		body: "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then echo v9.9.9; exit 0; fi\n",
+		mode: 0o755,
+	})
+	sum := sha256.Sum256(archive)
+	checksum := fmt.Sprintf("%x", sum[:])
+
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/" + assetName:
+			_, _ = response.Write(archive)
+		case "/checksums.txt":
+			fmt.Fprintf(response, "%s  %s\n", checksum, assetName)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	installDir := t.TempDir()
+	moltnetHome := missingMoltnetHome(t)
+	command := exec.Command("sh", "../../website/public/install.sh")
+	command.Env = append(os.Environ(),
+		"MOLTNET_DOWNLOAD_BASE_URL="+server.URL,
+		"MOLTNET_HOME="+moltnetHome,
+		"MOLTNET_INSTALL_DIR="+installDir,
+		"MOLTNET_REPO=example/moltnet",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install script failed: %v\n%s", err, output)
+	}
+
+	installedPath := filepath.Join(installDir, "moltnet")
+	if got := runVersion(t, installedPath); got != "v9.9.9" {
+		t.Fatalf("installed version = %q", got)
+	}
+
+	metadataPath := filepath.Join(moltnetHome, "install.json")
+	contents, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("read install metadata: %v\nscript output:\n%s", err, output)
+	}
+	var metadata installMetadata
+	if err := json.Unmarshal(contents, &metadata); err != nil {
+		t.Fatalf("decode install metadata: %v", err)
+	}
+	if !samePath(metadata.InstallPath, installedPath) ||
+		metadata.InstallMethod != string(InstallMethodReleaseTarball) ||
+		!metadata.SelfUpdateAllowed ||
+		metadata.OwnerRepo != "example/moltnet" ||
+		metadata.AssetName != assetName ||
+		metadata.AssetChecksum != "sha256:"+checksum ||
+		metadata.InstalledVersion != "v9.9.9" ||
+		metadata.InstalledBy != "install.sh" ||
+		metadata.Version != 1 {
+		t.Fatalf("unexpected metadata %#v", metadata)
+	}
+	info, err := os.Stat(metadataPath)
+	if err != nil {
+		t.Fatalf("stat install metadata: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("metadata permissions = %o, want 0600", got)
+	}
+}
+
+func TestInstallScriptDefaultsMetadataUnderHomeMoltnet(t *testing.T) {
+	assetName, err := AssetName(Platform{OS: runtime.GOOS, Arch: runtime.GOARCH})
+	if err != nil {
+		t.Skipf("unsupported test platform: %v", err)
+	}
+	server := newReleaseServer(t, fakeRelease{
+		assetName: assetName,
+		archive:   moltnetArchive(t, "v1.2.3"),
+		version:   "v1.2.3",
+	})
+	defer server.Close()
+
+	home := t.TempDir()
+	installDir := t.TempDir()
+	command := exec.Command("sh", "../../website/public/install.sh")
+	command.Env = withoutEnv(os.Environ(), "MOLTNET_HOME")
+	command.Env = append(command.Env,
+		"HOME="+home,
+		"MOLTNET_DOWNLOAD_BASE_URL="+server.URL,
+		"MOLTNET_INSTALL_DIR="+installDir,
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install script failed: %v\n%s", err, output)
+	}
+
+	metadataPath := filepath.Join(home, ".moltnet", "install.json")
+	if _, err := os.Stat(metadataPath); err != nil {
+		t.Fatalf("expected default metadata path: %v\n%s", err, output)
+	}
+	assertPrivateMode(t, filepath.Join(home, ".moltnet"), 0o700)
+	assertPrivateMode(t, metadataPath, 0o600)
+}
+
+func TestInstallScriptRefusesInsecureExistingMoltnetHomeWithoutChmod(t *testing.T) {
+	assetName, err := AssetName(Platform{OS: runtime.GOOS, Arch: runtime.GOARCH})
+	if err != nil {
+		t.Skipf("unsupported test platform: %v", err)
+	}
+	server := newReleaseServer(t, fakeRelease{
+		assetName: assetName,
+		archive:   moltnetArchive(t, "v1.2.3"),
+		version:   "v1.2.3",
+	})
+	defer server.Close()
+
+	moltnetHome := t.TempDir()
+	if err := os.Chmod(moltnetHome, 0o755); err != nil {
+		t.Fatalf("make Moltnet home insecure: %v", err)
+	}
+	defer os.Chmod(moltnetHome, 0o700)
+
+	command := exec.Command("sh", "../../website/public/install.sh")
+	command.Env = append(os.Environ(),
+		"MOLTNET_DOWNLOAD_BASE_URL="+server.URL,
+		"MOLTNET_HOME="+moltnetHome,
+		"MOLTNET_INSTALL_DIR="+t.TempDir(),
+	)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected install script to refuse insecure Moltnet home\n%s", output)
+	}
+	info, statErr := os.Stat(moltnetHome)
+	if statErr != nil {
+		t.Fatalf("stat Moltnet home: %v", statErr)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("install script changed existing Moltnet home mode to %o", got)
+	}
+}
+
+func TestInstallScriptMetadataAllowsInstalledMoltnetSelfUpdate(t *testing.T) {
+	if isContainerInstall() {
+		t.Skip("container detection refuses self-update")
+	}
+	assetName, err := AssetName(Platform{OS: runtime.GOOS, Arch: runtime.GOARCH})
+	if err != nil {
+		t.Skipf("unsupported test platform: %v", err)
+	}
+
+	oldServer := newReleaseServer(t, fakeRelease{
+		assetName: assetName,
+		archive:   moltnetBinaryArchive(t, buildMoltnetCLI(t, "v0.1.0")),
+		version:   "v0.1.0",
+	})
+	defer oldServer.Close()
+
+	installDir := t.TempDir()
+	moltnetHome := missingMoltnetHome(t)
+	install := exec.Command("sh", "../../website/public/install.sh")
+	install.Env = append(os.Environ(),
+		"MOLTNET_DOWNLOAD_BASE_URL="+oldServer.URL,
+		"MOLTNET_HOME="+moltnetHome,
+		"MOLTNET_INSTALL_DIR="+installDir,
+	)
+	if output, err := install.CombinedOutput(); err != nil {
+		t.Fatalf("install script failed: %v\n%s", err, output)
+	}
+
+	newServer := newReleaseServer(t, fakeRelease{
+		assetName: assetName,
+		archive:   moltnetBinaryArchive(t, buildMoltnetCLI(t, "v0.2.0")),
+		version:   "v0.2.0",
+	})
+	defer newServer.Close()
+
+	workspace := t.TempDir()
+	sentinels := writeRuntimeSentinels(t, workspace)
+	installedPath := filepath.Join(installDir, "moltnet")
+	update := exec.Command(installedPath, "update", "--yes")
+	update.Dir = workspace
+	update.Env = append(os.Environ(),
+		"MOLTNET_DOWNLOAD_BASE_URL="+newServer.URL,
+		"MOLTNET_HOME="+moltnetHome,
+	)
+	if output, err := update.CombinedOutput(); err != nil {
+		t.Fatalf("installed moltnet update failed: %v\n%s", err, output)
+	}
+	if got := runVersion(t, installedPath); got != "v0.2.0" {
+		t.Fatalf("installed version after update = %q", got)
+	}
+	assertSentinelsUnchanged(t, sentinels)
+
+	metadata := readInstallMetadataForTest(t, filepath.Join(moltnetHome, "install.json"))
+	if metadata.LastUpdate == nil ||
+		metadata.LastUpdate.FromVersion != "v0.1.0" ||
+		metadata.LastUpdate.ToVersion != "v0.2.0" ||
+		metadata.DownloadBaseURL != newServer.URL {
+		t.Fatalf("unexpected updated metadata %#v", metadata)
+	}
+}
+
+func buildMoltnetCLI(t *testing.T, version string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "moltnet")
+	command := exec.Command("go", "build", "-ldflags", "-X main.version="+version, "-o", path, "../../cmd/moltnet")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build moltnet %s: %v\n%s", version, err, output)
+	}
+	return path
+}
+
+func moltnetBinaryArchive(t *testing.T, binaryPath string) []byte {
+	t.Helper()
+
+	contents, err := os.ReadFile(binaryPath)
+	if err != nil {
+		t.Fatalf("read built moltnet binary: %v", err)
+	}
+	return archiveWithEntries(t, archiveEntry{name: "moltnet", body: string(contents), mode: 0o755})
+}
+
+func readInstallMetadataForTest(t *testing.T, path string) installMetadata {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read install metadata: %v", err)
+	}
+	var metadata installMetadata
+	if err := json.Unmarshal(contents, &metadata); err != nil {
+		t.Fatalf("decode install metadata: %v", err)
+	}
+	return metadata
+}
+
+func writeRuntimeSentinels(t *testing.T, workspace string) map[string][]byte {
+	t.Helper()
+
+	files := map[string]string{
+		"Moltnet":                "network_id: sentinel\n",
+		"MoltnetNode":            "attachments: []\n",
+		".moltnet/config.json":   `{"sentinel":"config"}` + "\n",
+		".moltnet/moltnet.db":    "sqlite sentinel\n",
+		".moltnet/agent.token":   "token sentinel\n",
+		".moltnet/sessions.json": `{"sentinel":"sessions"}` + "\n",
+	}
+	snapshots := make(map[string][]byte, len(files))
+	for name, contents := range files {
+		path := filepath.Join(workspace, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatalf("create sentinel dir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write sentinel %s: %v", name, err)
+		}
+		snapshots[path] = []byte(contents)
+	}
+	return snapshots
+}
+
+func assertSentinelsUnchanged(t *testing.T, snapshots map[string][]byte) {
+	t.Helper()
+
+	for path, want := range snapshots {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read sentinel %s: %v", path, err)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("sentinel %s changed: got %q want %q", path, got, want)
+		}
+	}
+}
+
+func assertPrivateMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %o, want %o", path, got, want)
+	}
+}
+
+func missingMoltnetHome(t *testing.T) string {
+	t.Helper()
+
+	return filepath.Join(t.TempDir(), "moltnet-home")
+}
+
+func withoutEnv(env []string, names ...string) []string {
+	blocked := map[string]struct{}{}
+	for _, name := range names {
+		blocked[name+"="] = struct{}{}
+	}
+	var filtered []string
+	for _, item := range env {
+		blockedItem := false
+		for prefix := range blocked {
+			if len(item) >= len(prefix) && item[:len(prefix)] == prefix {
+				blockedItem = true
+				break
+			}
+		}
+		if !blockedItem {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}

--- a/internal/updater/lock.go
+++ b/internal/updater/lock.go
@@ -45,6 +45,9 @@ func acquireUpdateLock(options updateLockOptions) (*updateLock, error) {
 	if staleAfter <= 0 {
 		staleAfter = defaultUpdateLockStaleAfter
 	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create update lock directory: %w", err)
+	}
 
 	for {
 		file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
@@ -136,11 +139,12 @@ func existingLockIsStale(path string, staleAfter time.Duration) (bool, error) {
 	return time.Since(info.ModTime()) > staleAfter, nil
 }
 
-func defaultUpdateLockPath(installPath string) string {
-	if strings.TrimSpace(installPath) == "" {
+func defaultUpdateLockPath(_ string) string {
+	home := defaultMoltnetHome()
+	if home == "" {
 		return ""
 	}
-	return filepath.Clean(installPath) + ".update.lock"
+	return filepath.Join(home, "update.lock")
 }
 
 func readUpdateLockRecord(path string) (updateLockRecord, bool) {

--- a/internal/updater/release.go
+++ b/internal/updater/release.go
@@ -114,6 +114,13 @@ func (s HTTPReleaseSource) ownerRepo() string {
 	return defaultOwnerRepo
 }
 
+func (s HTTPReleaseSource) InstallMetadata() ReleaseSourceMetadata {
+	return ReleaseSourceMetadata{
+		DownloadBaseURL: strings.TrimSpace(s.DownloadBaseURL),
+		OwnerRepo:       s.ownerRepo(),
+	}
+}
+
 func (s HTTPReleaseSource) get(ctx context.Context, requestURL string) ([]byte, error) {
 	client := s.Client
 	if client == nil {

--- a/internal/updater/run_hardening_test.go
+++ b/internal/updater/run_hardening_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestRunWritesInstallMetadataAfterUpdate(t *testing.T) {
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
+	moltnetHome := missingMoltnetHome(t)
+	t.Setenv(moltnetHomeEnv, moltnetHome)
 
 	assetName := "moltnet_linux_amd64.tar.gz"
 	archive := moltnetArchive(t, "v0.2.0")
@@ -28,7 +28,9 @@ func TestRunWritesInstallMetadataAfterUpdate(t *testing.T) {
 	defer server.Close()
 
 	installPath := writeMoltnetScript(t, t.TempDir(), "v0.1.0")
-	result, err := Run(context.Background(), releaseUpdateOptions(server, installPath))
+	options := releaseUpdateOptions(server, installPath)
+	options.ReleaseSource = HTTPReleaseSource{Client: server.Client(), DownloadBaseURL: server.URL, OwnerRepo: "example/moltnet"}
+	result, err := Run(context.Background(), options)
 	if err != nil {
 		t.Fatalf("Run() update error = %v", err)
 	}
@@ -36,7 +38,7 @@ func TestRunWritesInstallMetadataAfterUpdate(t *testing.T) {
 		t.Fatalf("expected update result %#v", result)
 	}
 
-	metadataPath := filepath.Join(stateHome, "moltnet", "install.json")
+	metadataPath := filepath.Join(moltnetHome, "install.json")
 	contents, err := os.ReadFile(metadataPath)
 	if err != nil {
 		t.Fatalf("read install metadata: %v", err)
@@ -44,6 +46,7 @@ func TestRunWritesInstallMetadataAfterUpdate(t *testing.T) {
 	var metadata struct {
 		AssetChecksum    string `json:"asset_checksum"`
 		AssetName        string `json:"asset_name"`
+		DownloadBaseURL  string `json:"download_base_url"`
 		InstallMethod    string `json:"install_method"`
 		InstallPath      string `json:"install_path"`
 		InstalledAt      string `json:"installed_at"`
@@ -55,6 +58,7 @@ func TestRunWritesInstallMetadataAfterUpdate(t *testing.T) {
 			Status      string `json:"status"`
 			ToVersion   string `json:"to_version"`
 		} `json:"last_update"`
+		OwnerRepo         string `json:"owner_repo"`
 		PreviousBinary    string `json:"previous_binary"`
 		SelfUpdateAllowed bool   `json:"self_update_allowed"`
 		Version           int    `json:"version"`
@@ -69,7 +73,9 @@ func TestRunWritesInstallMetadataAfterUpdate(t *testing.T) {
 		!metadata.SelfUpdateAllowed ||
 		metadata.AssetName != assetName ||
 		metadata.AssetChecksum != wantChecksum ||
+		metadata.DownloadBaseURL != server.URL ||
 		metadata.InstalledVersion != "v0.2.0" ||
+		metadata.OwnerRepo != "example/moltnet" ||
 		metadata.PreviousBinary != result.BackupPath ||
 		metadata.Version != 1 ||
 		metadata.InstalledBy != "moltnet update" ||
@@ -94,8 +100,8 @@ func TestRunWritesInstallMetadataAfterUpdate(t *testing.T) {
 }
 
 func TestRunTreatsInstallMetadataFailureAsPostUpdateWarning(t *testing.T) {
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
+	moltnetHome := missingMoltnetHome(t)
+	t.Setenv(moltnetHomeEnv, moltnetHome)
 
 	assetName := "moltnet_linux_amd64.tar.gz"
 	server := newReleaseServer(t, fakeRelease{
@@ -105,7 +111,7 @@ func TestRunTreatsInstallMetadataFailureAsPostUpdateWarning(t *testing.T) {
 	})
 	defer server.Close()
 
-	metadataDir := filepath.Join(stateHome, "moltnet")
+	metadataDir := moltnetHome
 	if err := os.MkdirAll(metadataDir, 0o700); err != nil {
 		t.Fatalf("create metadata dir: %v", err)
 	}
@@ -137,8 +143,8 @@ func TestDefaultInstallDetectorRefusesDevelopmentVersionDespiteStaleMetadata(t *
 	if isContainerInstall() {
 		t.Skip("container detection takes precedence over local install metadata")
 	}
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
+	moltnetHome := missingMoltnetHome(t)
+	t.Setenv(moltnetHomeEnv, moltnetHome)
 
 	executable, err := os.Executable()
 	if err != nil {
@@ -164,8 +170,8 @@ func TestDefaultInstallDetectorRefusesDevelopmentVersionDespiteStaleMetadata(t *
 }
 
 func TestRunRechecksInstalledBinaryBeforeNoop(t *testing.T) {
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
+	moltnetHome := missingMoltnetHome(t)
+	t.Setenv(moltnetHomeEnv, moltnetHome)
 
 	assetName := "moltnet_linux_amd64.tar.gz"
 	server := newReleaseServer(t, fakeRelease{
@@ -187,7 +193,7 @@ func TestRunRechecksInstalledBinaryBeforeNoop(t *testing.T) {
 		t.Fatalf("expected rechecked install version to drive update, got %#v", result)
 	}
 
-	contents, err := os.ReadFile(filepath.Join(stateHome, "moltnet", "install.json"))
+	contents, err := os.ReadFile(filepath.Join(moltnetHome, "install.json"))
 	if err != nil {
 		t.Fatalf("read install metadata: %v", err)
 	}
@@ -205,6 +211,12 @@ func TestRunRechecksInstalledBinaryBeforeNoop(t *testing.T) {
 }
 
 func TestRunRefusesConcurrentUpdateLock(t *testing.T) {
+	moltnetHome := missingMoltnetHome(t)
+	t.Setenv(moltnetHomeEnv, moltnetHome)
+	if err := os.MkdirAll(moltnetHome, 0o700); err != nil {
+		t.Fatalf("create Moltnet home: %v", err)
+	}
+
 	assetName := "moltnet_linux_amd64.tar.gz"
 	server := newReleaseServer(t, fakeRelease{
 		assetName: assetName,
@@ -214,11 +226,12 @@ func TestRunRefusesConcurrentUpdateLock(t *testing.T) {
 	defer server.Close()
 
 	installPath := writeMoltnetScript(t, t.TempDir(), "v0.1.0")
-	if err := os.WriteFile(defaultUpdateLockPath(installPath), []byte("active"), 0o600); err != nil {
+	options := releaseUpdateOptions(server, installPath)
+	if err := os.WriteFile(options.LockPath, []byte("active"), 0o600); err != nil {
 		t.Fatalf("write active lock: %v", err)
 	}
 
-	result, err := Run(context.Background(), releaseUpdateOptions(server, installPath))
+	result, err := Run(context.Background(), options)
 	if err == nil {
 		t.Fatal("expected active lock error")
 	}
@@ -230,6 +243,108 @@ func TestRunRefusesConcurrentUpdateLock(t *testing.T) {
 	}
 	if got := runVersion(t, installPath); got != "v0.1.0" {
 		t.Fatalf("lock refusal mutated install, version = %q", got)
+	}
+}
+
+func TestRunUsesMoltnetHomeUpdateLockByDefault(t *testing.T) {
+	moltnetHome := missingMoltnetHome(t)
+	t.Setenv(moltnetHomeEnv, moltnetHome)
+	if err := os.MkdirAll(moltnetHome, 0o700); err != nil {
+		t.Fatalf("create Moltnet home: %v", err)
+	}
+
+	assetName := "moltnet_linux_amd64.tar.gz"
+	server := newReleaseServer(t, fakeRelease{
+		assetName: assetName,
+		archive:   moltnetArchive(t, "v0.2.0"),
+		version:   "v0.2.0",
+	})
+	defer server.Close()
+
+	lockPath := filepath.Join(moltnetHome, "update.lock")
+	if err := os.WriteFile(lockPath, []byte("active"), 0o600); err != nil {
+		t.Fatalf("write active default lock: %v", err)
+	}
+	installPath := writeMoltnetScript(t, t.TempDir(), "v0.1.0")
+	options := releaseUpdateOptions(server, installPath)
+	options.LockPath = ""
+
+	result, err := Run(context.Background(), options)
+	if err == nil {
+		t.Fatal("expected default lock refusal")
+	}
+	if !strings.Contains(err.Error(), "already running") {
+		t.Fatalf("unexpected lock error %v", err)
+	}
+	if result.Updated {
+		t.Fatalf("lock refusal updated install %#v", result)
+	}
+	if _, err := os.Stat(installPath + ".update.lock"); !os.IsNotExist(err) {
+		t.Fatalf("install-local lock was used, stat err=%v", err)
+	}
+}
+
+func TestDefaultInstallDetectorIgnoresInsecureMetadata(t *testing.T) {
+	if isContainerInstall() {
+		t.Skip("container detection takes precedence over local install metadata")
+	}
+	moltnetHome := missingMoltnetHome(t)
+	t.Setenv(moltnetHomeEnv, moltnetHome)
+	if err := os.MkdirAll(moltnetHome, 0o700); err != nil {
+		t.Fatalf("create Moltnet home: %v", err)
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable(): %v", err)
+	}
+	metadata := installMetadata{
+		InstallMethod:     string(InstallMethodReleaseTarball),
+		InstallPath:       cleanExecutablePath(executable),
+		SelfUpdateAllowed: true,
+		Version:           1,
+	}
+	contents, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	metadataPath := filepath.Join(moltnetHome, "install.json")
+	if err := os.WriteFile(metadataPath, append(contents, '\n'), 0o644); err != nil {
+		t.Fatalf("write insecure metadata: %v", err)
+	}
+
+	install, err := (DefaultInstallDetector{}).DetectInstall(context.Background(), "v0.1.0")
+	if err != nil {
+		t.Fatalf("DetectInstall() error = %v", err)
+	}
+	if install.Method != InstallMethodUnknown || install.SelfUpdateAllowed {
+		t.Fatalf("expected insecure metadata to be ignored, got %#v", install)
+	}
+}
+
+func TestWriteInstallMetadataRefusesInsecureExistingHomeWithoutChmod(t *testing.T) {
+	moltnetHome := t.TempDir()
+	t.Setenv(moltnetHomeEnv, moltnetHome)
+	if err := os.Chmod(moltnetHome, 0o755); err != nil {
+		t.Fatalf("make home insecure: %v", err)
+	}
+	defer os.Chmod(moltnetHome, 0o700)
+
+	err := writeInstallMetadata(installMetadata{
+		InstallMethod:     string(InstallMethodReleaseTarball),
+		InstallPath:       "/tmp/moltnet",
+		SelfUpdateAllowed: true,
+		Version:           1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "group/world accessible") {
+		t.Fatalf("expected insecure home refusal, got %v", err)
+	}
+	info, statErr := os.Stat(moltnetHome)
+	if statErr != nil {
+		t.Fatalf("stat moltnet home: %v", statErr)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("writeInstallMetadata changed existing home mode to %o", got)
 	}
 }
 

--- a/internal/updater/types.go
+++ b/internal/updater/types.go
@@ -70,6 +70,11 @@ type ReleaseSource interface {
 	Checksums(ctx context.Context, version string) ([]byte, error)
 }
 
+type ReleaseSourceMetadata struct {
+	DownloadBaseURL string
+	OwnerRepo       string
+}
+
 type ServerProbe interface {
 	ProbeServer(ctx context.Context, request ServerProbeRequest) (ServerInfo, error)
 }

--- a/internal/updater/update.go
+++ b/internal/updater/update.go
@@ -140,10 +140,12 @@ func Run(ctx context.Context, options Options) (Result, error) {
 	result.BackupPath = backupPath
 	result.Updated = true
 	finishedAt := time.Now().UTC().Format(time.RFC3339)
+	sourceMetadata := releaseSourceMetadata(options.ReleaseSource)
 	if err := writeInstallMetadata(installMetadata{
 		Arch:              options.Platform.Arch,
 		AssetChecksum:     normalizeAssetChecksum(checksum),
 		AssetName:         assetName,
+		DownloadBaseURL:   sourceMetadata.DownloadBaseURL,
 		InstallMethod:     string(InstallMethodReleaseTarball),
 		InstallPath:       install.Path,
 		InstalledAt:       finishedAt,
@@ -151,7 +153,7 @@ func Run(ctx context.Context, options Options) (Result, error) {
 		InstalledVersion:  targetVersion,
 		LastUpdate:        &installMetadataLastUpdate{Status: "succeeded", FromVersion: result.CurrentVersion, ToVersion: targetVersion, FinishedAt: finishedAt},
 		OS:                options.Platform.OS,
-		OwnerRepo:         defaultOwnerRepo,
+		OwnerRepo:         sourceMetadata.OwnerRepo,
 		PreviousBinary:    backupPath,
 		SelfUpdateAllowed: true,
 		Version:           1,
@@ -207,6 +209,20 @@ func resolveTargetVersion(ctx context.Context, options Options) (string, error) 
 		return "", err
 	}
 	return strings.TrimSpace(version), nil
+}
+
+func releaseSourceMetadata(source ReleaseSource) ReleaseSourceMetadata {
+	type metadataSource interface {
+		InstallMetadata() ReleaseSourceMetadata
+	}
+	if source, ok := source.(metadataSource); ok {
+		metadata := source.InstallMetadata()
+		if strings.TrimSpace(metadata.OwnerRepo) == "" {
+			metadata.OwnerRepo = defaultOwnerRepo
+		}
+		return metadata
+	}
+	return ReleaseSourceMetadata{OwnerRepo: defaultOwnerRepo}
 }
 
 func versionDiffers(current string, target string) (bool, error) {

--- a/internal/updater/update_test.go
+++ b/internal/updater/update_test.go
@@ -224,6 +224,8 @@ func TestRunErrorsOnMissingAsset(t *testing.T) {
 }
 
 func TestRunReplacesTempInstallRoot(t *testing.T) {
+	t.Setenv(moltnetHomeEnv, t.TempDir())
+
 	assetName := "moltnet_linux_amd64.tar.gz"
 	server := newReleaseServer(t, fakeRelease{
 		assetName: assetName,
@@ -320,6 +322,7 @@ func releaseUpdateOptions(server *fakeReleaseServer, installPath string) Options
 			Path:              installPath,
 			SelfUpdateAllowed: true,
 		}},
+		LockPath:      installPath + ".test.update.lock",
 		Platform:      Platform{OS: "linux", Arch: "amd64"},
 		ReleaseSource: HTTPReleaseSource{Client: server.Client(), DownloadBaseURL: server.URL},
 	}

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -3,6 +3,7 @@ set -eu
 
 OWNER_REPO="${MOLTNET_REPO:-noopolis/moltnet}"
 INSTALL_DIR="${MOLTNET_INSTALL_DIR:-$HOME/.local/bin}"
+MOLTNET_STATE_DIR="${MOLTNET_HOME:-$HOME/.moltnet}"
 BINARY_URL_BASE="${MOLTNET_DOWNLOAD_BASE_URL:-}"
 BINARIES="moltnet"
 
@@ -70,6 +71,7 @@ download_release() {
       echo "Installed ${bin} to ${INSTALL_DIR}/${bin}" >&2
     fi
   done
+  write_install_metadata "$asset" "$os" "$arch" "$VERIFIED_SHA256"
 
   echo "Make sure ${INSTALL_DIR} is on your PATH." >&2
 }
@@ -105,10 +107,98 @@ verify_checksum() {
     echo "error: checksum mismatch for ${asset}" >&2
     exit 1
   fi
+  VERIFIED_SHA256="$actual"
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g'
+}
+
+file_mode() {
+  path="$1"
+  if mode="$(stat -c '%a' "$path" 2>/dev/null)"; then
+    echo "$mode"
+    return 0
+  fi
+  stat -f '%Lp' "$path"
+}
+
+ensure_private_state_dir() {
+  if [ -L "$MOLTNET_STATE_DIR" ]; then
+    echo "error: refusing Moltnet state directory symlink ${MOLTNET_STATE_DIR}" >&2
+    exit 1
+  fi
+  if [ -e "$MOLTNET_STATE_DIR" ]; then
+    if [ ! -d "$MOLTNET_STATE_DIR" ]; then
+      echo "error: Moltnet state path is not a directory ${MOLTNET_STATE_DIR}" >&2
+      exit 1
+    fi
+    mode="$(file_mode "$MOLTNET_STATE_DIR")"
+    if [ "$mode" != "700" ]; then
+      echo "error: Moltnet state directory must be private (chmod 700 ${MOLTNET_STATE_DIR})" >&2
+      exit 1
+    fi
+    return 0
+  fi
+
+  mkdir -p -m 700 "$MOLTNET_STATE_DIR"
+  mode="$(file_mode "$MOLTNET_STATE_DIR")"
+  if [ "$mode" != "700" ]; then
+    echo "error: Moltnet state directory must be private (chmod 700 ${MOLTNET_STATE_DIR})" >&2
+    exit 1
+  fi
+}
+
+write_install_metadata() {
+  asset="$1"
+  os="$2"
+  arch="$3"
+  checksum="$4"
+  installed_dir="$(cd "$INSTALL_DIR" && pwd -P)"
+  installed_path="${installed_dir}/moltnet"
+  metadata_path="${MOLTNET_STATE_DIR}/install.json"
+
+  if [ ! -x "$installed_path" ]; then
+    echo "warning: skipping install metadata because ${installed_path} is not executable" >&2
+    return 0
+  fi
+  if [ -L "$metadata_path" ]; then
+    echo "error: refusing install metadata symlink ${metadata_path}" >&2
+    exit 1
+  fi
+
+  installed_version="$("$installed_path" version 2>/dev/null || true)"
+  installed_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+  ensure_private_state_dir
+
+  tmp_metadata="$(mktemp "${MOLTNET_STATE_DIR}/.install.XXXXXX")"
+  cat >"$tmp_metadata" <<EOF
+{
+  "version": 1,
+  "install_path": "$(json_escape "$installed_path")",
+  "install_method": "release-tarball",
+  "self_update_allowed": true,
+  "owner_repo": "$(json_escape "$OWNER_REPO")",
+  "download_base_url": "$(json_escape "$BINARY_URL_BASE")",
+  "asset_name": "$(json_escape "$asset")",
+  "asset_checksum": "sha256:$(json_escape "$checksum")",
+  "os": "$(json_escape "$os")",
+  "arch": "$(json_escape "$arch")",
+  "installed_version": "$(json_escape "$installed_version")",
+  "installed_at": "$(json_escape "$installed_at")",
+  "installed_by": "install.sh"
+}
+EOF
+  chmod 600 "$tmp_metadata"
+  mv "$tmp_metadata" "$metadata_path"
+  echo "Wrote install metadata to ${metadata_path}" >&2
 }
 
 need_cmd curl
 need_cmd tar
 need_cmd install
+need_cmd sed
+need_cmd stat
 
 download_release

--- a/website/src/content/docs/guides/operating-moltnet.md
+++ b/website/src/content/docs/guides/operating-moltnet.md
@@ -64,6 +64,8 @@ For SQLite, stop the server or use `sqlite3 .backup` before the restart. For Pos
 
 `moltnet update --check` is the non-mutating preflight for release installs. `moltnet update` replaces the installed release binary, then still requires a separate server restart for foreground processes. Container deployments should pull a new image and restart through the orchestrator instead of self-updating inside the container.
 
+Release installer ownership metadata is stored in `~/.moltnet/install.json` by default. Set `MOLTNET_HOME` when you need that global install/update state somewhere else. Do not confuse this with a workspace or server `.moltnet` directory; update metadata describes the installed executable, not a specific Moltnet network.
+
 ## Network identity
 
 The `network_id` should not change after messages have been stored. It is embedded in FQIDs and origin metadata. Changing it breaks references from paired networks.
@@ -90,7 +92,7 @@ Moltnet v0.1 does not include core abuse rate limiting for open registration. Co
 
 ## Backup
 
-- SQLite: copy `.moltnet/moltnet.db` (WAL mode supports concurrent reads)
+- SQLite: stop Moltnet and run `sqlite3 .moltnet/moltnet.db ".backup '.moltnet/moltnet.db.backup-YYYYMMDDTHHMMSSZ'"`; if `sqlite3` is unavailable, stop Moltnet and copy `moltnet.db`, `moltnet.db-wal`, and `moltnet.db-shm` together
 - PostgreSQL: use `pg_dump`
 - JSON: copy the JSON file
 - Open-mode agents: back up node token files and workspace `.moltnet/config.json` files that contain generated agent tokens

--- a/website/src/content/docs/install.md
+++ b/website/src/content/docs/install.md
@@ -9,15 +9,23 @@ description: How to install Moltnet.
 curl -fsSL https://moltnet.dev/install.sh | sh
 ```
 
-This downloads the latest release for your platform and installs the `moltnet` binary to `~/.local/bin`.
+This downloads the latest release for your platform, installs the `moltnet` binary to `~/.local/bin`, and writes install metadata to `~/.moltnet/install.json`.
 
 One binary — it includes the server, the node that runs your agents, the CLI client, and the skill-install workflows.
 
 To install to a different directory:
 
 ```bash
-MOLTNET_INSTALL_DIR=/usr/local/bin curl -fsSL https://moltnet.dev/install.sh | sh
+curl -fsSL https://moltnet.dev/install.sh | MOLTNET_INSTALL_DIR=/usr/local/bin sh
 ```
+
+To keep Moltnet's global install/update state somewhere else:
+
+```bash
+curl -fsSL https://moltnet.dev/install.sh | MOLTNET_HOME=/opt/moltnet-state sh
+```
+
+`MOLTNET_HOME` is global install state for the current user. It is separate from workspace or server `.moltnet` directories that hold config, tokens, sessions, and storage files. If you install with `MOLTNET_HOME`, use the same value when running `moltnet update`.
 
 ## From source
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -24,7 +24,9 @@ moltnet update --yes
 
 Update means binary replacement, not reset. It must not delete `Moltnet`, `MoltnetNode`, `.moltnet`, SQLite files, Postgres data, rooms, messages, agent registrations, or tokens. A running foreground `moltnet start` process keeps using the old binary until you restart it.
 
-`moltnet update --check` is the non-mutating discovery path. With `--server`, it also reports the running server version and `/v1/network` compatibility metadata when the endpoint is readable. If the server requires bearer auth, pass the token intentionally with `--server-token-env`; Moltnet does not send ambient update tokens to arbitrary server URLs.
+Release installer metadata lives in `~/.moltnet/install.json` by default. Set `MOLTNET_HOME` to use a different global install-state directory, and use the same value for later `moltnet update` runs. This is separate from project-local `.moltnet` directories used for runtime config, tokens, sessions, and storage.
+
+`moltnet update --check` is the non-mutating discovery path. With `--server`, it probes `/v1/network` and reports the running server version when the endpoint is readable. If the server requires bearer auth, pass the token intentionally with `--server-token-env`; Moltnet does not send ambient update tokens to arbitrary server URLs.
 
 Docker and container installs should not self-update from inside the container. Pull the newer image and restart the container using your normal deployment flow.
 


### PR DESCRIPTION
## Summary

- move Moltnet release install metadata and update locks to `MOLTNET_HOME`, defaulting to `~/.moltnet`
- make `install.sh` write ownership metadata and refuse unsafe existing state directories instead of mutating permissions
- harden updater metadata reads and preserve release-source provenance during self-update
- document the `~/.moltnet` global state split and add WAL-safe backup guidance

## Validation

- `go test ./internal/updater`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `staticcheck ./...`
- `cd website && npm run build`
- `git diff --check`