### PR TITLE
ci: streamline release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,74 +9,8 @@ permissions:
   contents: write
 
 jobs:
-  verify-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-
-      - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
-        with:
-          go-version-file: go.mod
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      - name: Install console deps
-        working-directory: web
-        run: npm ci
-
-      - name: Typecheck console
-        working-directory: web
-        run: npm run typecheck
-
-      - name: Build console
-        working-directory: web
-        run: npm run build
-
-      - name: Check embedded console assets
-        run: git diff --exit-code web/dist
-
-      - name: Verify published Stele corpus
-        run: ./scripts/verify-stele-corpus.sh
-
-      - name: Go vet
-        run: go vet ./...
-
-      - name: Staticcheck
-        run: |
-          go install honnef.co/go/tools/cmd/staticcheck@v0.6.1
-          "$(go env GOPATH)/bin/staticcheck" ./...
-
-      - name: Check go mod tidy
-        shell: bash
-        run: |
-          set -euo pipefail
-          go mod tidy
-          git diff --exit-code go.mod go.sum
-
-      - name: Go test with coverage
-        run: go test ./... -coverprofile=coverage.out -covermode=atomic
-
-      - name: Enforce coverage threshold
-        shell: bash
-        run: |
-          set -euo pipefail
-          go tool cover -func=coverage.out | tee coverage.txt
-          total="$(awk '/^total:/{gsub("%","",$3); print $3}' coverage.txt)"
-          awk -v total="$total" 'BEGIN { if (total + 0 < 80.0) exit 1 }'
-
-      - name: Go test -race
-        run: go test -race ./...
-
   build-assets:
     runs-on: ubuntu-latest
-    needs: verify-release
     strategy:
       fail-fast: false
       matrix:
@@ -97,21 +31,6 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      - name: Install console deps
-        working-directory: web
-        run: npm ci
-
-      - name: Build console
-        working-directory: web
-        run: npm run build
 
       - name: Build release tarball
         shell: bash


### PR DESCRIPTION
Keeps vet, static analysis, coverage, race tests, console validation, and corpus checks in the existing pull-request/main workflow. The tag workflow now only builds the four release binaries and publishes their checksummed artifacts.